### PR TITLE
Fix source url typo

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Coerce.Mixfile do
       description: description(),
       package: package(),
       name: "Coerce",
-      source_url: "https://gitub.com/Qqwy/elixir-coerce"
+      source_url: "https://github.com/Qqwy/elixir-coerce"
     ]
   end
 


### PR DESCRIPTION
Fix `source_url` typo error