### PR TITLE
Fix coerce/2 check on Elixir 1.19

### DIFF
--- a/lib/coerce.ex
+++ b/lib/coerce.ex
@@ -115,6 +115,9 @@ defmodule Coerce do
         @moduledoc false
         unquote(block)
       end
+
+      Code.ensure_compiled!(unquote(primary_module))
+
       unless function_exported?(unquote(primary_module), :coerce, 2) do
         raise Coerce.CompileError, "`Coerce.defcoercion` implementation does not implement `coerce/2`."
       end


### PR DESCRIPTION
Elixir 1.19 is causing `defcoercion`  to fail because the module isn't be available  when `function_exported?` runs. Adding `Code.ensure_compiled!` makes the check work on all versions. 

Issue similar to https://github.com/elixir-lang/elixir/issues/14578